### PR TITLE
code for cone pt studies

### DIFF
--- a/nanoFakes_conept.C
+++ b/nanoFakes_conept.C
@@ -1,0 +1,662 @@
+#define nanoFakes_conept_cxx
+
+
+#include "nanoFakes_conept.h"
+#include <TStyle.h>
+
+
+// Data members
+//------------------------------------------------------------------------------
+string         option;
+TString        filename;
+TString        year;
+
+TFile*         root_output;
+
+bool           ismc;
+int            channel;
+float          inputJetEt;
+float          leptonPtMin;
+float          leptonEtaMax;
+float          event_weight;
+float          l2tight_weight;
+float          deltaR;
+float          eleLowPtPrescale = 0.0;
+float          eleHighPtPrescale = 0.0;
+float          muonLowPtPrescale = 0.0;
+float          muonHighPtPrescale = 0.0;
+
+/*float elePrescale8 = 0.0;
+float elePrescale17 = 0.0;
+float elePrescale23 = 0.0;
+
+float muonPrescale8 = 0.0;
+float muonPrescale17 = 0.0;
+float muonPrescale20 = 0.0;
+float muonPrescale27 = 0.0;
+*/
+
+TLorentzVector tlv1;
+TLorentzVector tlv2;
+
+int            jetIndex;
+int            leptonIndex;
+
+int            counter    = 0;
+int            nentries   = 0;
+int            maxentries = -1;
+
+int            counter1 = 0;
+int            counter2 = 0;
+
+//------------------------------------------------------------------------------
+// Begin
+//------------------------------------------------------------------------------
+void nanoFakes_conept::Begin(TTree*)
+{
+  // The Begin() function is called at the start of the query.
+  // When running with PROOF Begin() is only called on the client.
+  // The tree argument is deprecated (on PROOF 0 is passed).
+
+  option = GetOption();
+  printf("\n");
+
+  printf("   option: %s\n", option.c_str());
+
+  year     = option.substr(0,4);
+  filename = option.erase(0,4);
+
+  printf("     year: %s\n", year.Data());
+  printf(" filename: %s\n", filename.Data());
+
+  printf("\n");
+  
+  if (!filename.Contains("Run201")) {
+
+    baseW            = {fReader, "baseW"};
+    Xsec             = {fReader, "Xsec"};
+    puWeight         = {fReader, "puWeight"};
+    Generator_weight = {fReader, "Generator_weight"};
+  }
+
+  ismc = (filename.Contains("Run201")) ? false : true;
+
+  root_output = new TFile("results/" + filename + ".root", "recreate");
+
+  TH1::SetDefaultSumw2();
+
+  //Prescale definition depending on the year
+  if(year == "2016") {
+    //    eleLowPtPrescale = 14.851;
+    //    eleHighPtPrescale = 62.808;
+    //    muonLowPtPrescale = 7.801;
+    //    muonHighPtPrescale = 216.748;
+    eleLowPtPrescale = 6.979;
+    eleHighPtPrescale = 62.66;
+    muonLowPtPrescale = 3.909;
+    muonHighPtPrescale = 281.99;
+  } else if(year == "2017") {
+    eleLowPtPrescale = 3.973; //Ele8
+    //////eleLowPtPrescale = 27.699; //Ele12
+    eleHighPtPrescale = 43.469;
+    muonLowPtPrescale = 2.903;
+    muonHighPtPrescale = 65.944;
+  } else if(year == "2018") {
+    eleLowPtPrescale = 6.412; //Ele8
+    //////eleLowPtPrescale = 38.849; //Ele12
+    eleHighPtPrescale = 38.906;
+    muonLowPtPrescale = 8.561;
+    muonHighPtPrescale = 45.781;
+  }
+
+  //Tight Ele and mu WP definition
+  if (year == "2016") {
+    muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight80x"}; // v6 and v7
+    //muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight80x_tthmva_80"}; // v6 and v7
+    eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016"}; // v7
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016_tthmva_70"}; // v7
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016_SS"}; // v7
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016_SS_tthmva_70"}; // v7
+    //
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cut_WP_Tight80X"}; // v6
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cut_WP_Tight80X_SS"}; // v6
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016"}; // v6
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016_SS"}; // v6
+  } else if(year == "2017") {
+    //muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight_HWWW"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90"};
+    muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight_HWWW_tthmva_80"}; // v6 and v7
+    eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_tthmva_70"}; // v7
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight_SS"};
+  } else if(year == "2018") {
+    //muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight_HWWW"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90"};
+    muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight_HWWW_tthmva_80"}; // v6 and v7
+    eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_tthmva_70"}; // v7
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight_SS"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight"};
+    //eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight_SS"};
+  } else {
+    std::cout << "WARNING: the year you specified is not 2016, 2017, or 2018!" << std::endl;
+  }
+
+  for (int btag = 0; btag < nbtag ; btag ++) {	  	
+  // FR regions
+  //----------------------------------------------------------------------------
+    
+    btagDirectory = btags[btag];
+    root_output->cd();
+    gDirectory->mkdir(btagDirectory);
+    root_output->cd(btagDirectory);
+
+    for (int i=0; i<ncutFR; i++) {
+	
+      TString directory = scutFR[i];
+      
+      root_output->cd();
+      root_output->cd(btagDirectory);
+      gDirectory->mkdir(directory);
+      root_output->cd(btagDirectory+"/"+directory);
+      
+      for (int j=0; j<njetet; j++) {
+	
+	TString muonsuffix = Form("_%.0fGeV", muonjetet[j]);
+	TString elesuffix  = Form("_%.0fGeV", elejetet[j]);
+	
+	// Fake rate histograms
+	//------------------------------------------------------------------------
+	h_Muon_loose_pt_eta_bin[i][j][btag] = new TH2D("h_Muon_loose_pt_eta_bin" + muonsuffix, "", nptbin, ptbins, netabin, etabins);
+	h_Muon_tight_pt_eta_bin[i][j][btag] = new TH2D("h_Muon_tight_pt_eta_bin" + muonsuffix, "", nptbin, ptbins, netabin, etabins);
+	h_Ele_loose_pt_eta_bin [i][j][btag] = new TH2D("h_Ele_loose_pt_eta_bin"  + elesuffix,  "", nptbin, ptbins, netabin, etabins);
+	h_Ele_tight_pt_eta_bin [i][j][btag] = new TH2D("h_Ele_tight_pt_eta_bin"  + elesuffix,  "", nptbin, ptbins, netabin, etabins);
+	
+	h_Muon_loose_pt_bin[i][j][btag] = new TH1D("h_Muon_loose_pt_bin" + muonsuffix, "", nptbin, ptbins);
+	h_Muon_tight_pt_bin[i][j][btag] = new TH1D("h_Muon_tight_pt_bin" + muonsuffix, "", nptbin, ptbins);
+	h_Ele_loose_pt_bin [i][j][btag] = new TH1D("h_Ele_loose_pt_bin"  + elesuffix,  "", nptbin, ptbins);
+	h_Ele_tight_pt_bin [i][j][btag] = new TH1D("h_Ele_tight_pt_bin"  + elesuffix,  "", nptbin, ptbins);
+	
+	h_Muon_loose_eta_bin[i][j][btag] = new TH1D("h_Muon_loose_eta_bin" + muonsuffix, "", netabin, etabins);
+	h_Muon_tight_eta_bin[i][j][btag] = new TH1D("h_Muon_tight_eta_bin" + muonsuffix, "", netabin, etabins);
+	h_Ele_loose_eta_bin[i][j][btag] = new TH1D("h_Ele_loose_eta_bin"  + elesuffix,  "", netabin, etabins);
+	h_Ele_tight_eta_bin[i][j][btag] = new TH1D("h_Ele_tight_eta_bin"  + elesuffix,  "", netabin, etabins);
+
+	//h_Muon_loose_dRlj_bin[i][j][btag] = new TH1D("h_Muon_loose_dRlj_bin" + muonsuffix, "", 30, 0., 3.0);
+	//h_Ele_loose_dRlj_bin[i][j][btag] = new TH1D("h_Ele_loose_dRlj_bin" + muonsuffix, "", 30, 0., 3.0);
+	//h_Muon_tight_dRlj_bin[i][j][btag] = new TH1D("h_Muon_tight_dRlj_bin" + muonsuffix, "", 30, 0., 3.0);
+	//h_Ele_tight_dRlj_bin[i][j][btag] = new TH1D("h_Ele_tight_dRlj_bin" + muonsuffix, "", 30, 0., 3.0);
+	h_Muon_Jet_loose_pt_bin[i][j][btag] = new TH1D("h_Muon_Jet_loose_pt_bin" + muonsuffix, "", nptbin, ptbins);
+	h_Muon_Jet_tight_pt_bin[i][j][btag] = new TH1D("h_Muon_Jet_tight_pt_bin" + muonsuffix, "", nptbin, ptbins);
+	h_Ele_Jet_loose_pt_bin[i][j][btag] = new TH1D("h_Ele_Jet_loose_pt_bin" + elesuffix, "", nptbin, ptbins);
+	h_Ele_Jet_tight_pt_bin[i][j][btag] = new TH1D("h_Ele_Jet_tight_pt_bin" + elesuffix, "", nptbin, ptbins);
+
+      }	
+    }
+  }
+    
+  // PR regions
+  //----------------------------------------------------------------------------
+  for (int i=0; i<ncutPR; i++) {
+    
+    TString directory = scutPR[i];
+    
+    root_output->cd();
+    gDirectory->mkdir(directory);
+    root_output->cd(directory);
+    
+    // Prompt rate histograms
+    //--------------------------------------------------------------------------
+    h_Muon_loose_pt_eta_PR[i] = new TH2D("h_Muon_loose_pt_eta_PR", "", nptbin, ptbins, netabin, etabins);
+    h_Muon_tight_pt_eta_PR[i] = new TH2D("h_Muon_tight_pt_eta_PR", "", nptbin, ptbins, netabin, etabins);
+    h_Ele_loose_pt_eta_PR[i]  = new TH2D("h_Ele_loose_pt_eta_PR",  "", nptbin, ptbins, netabin, etabins);
+    h_Ele_tight_pt_eta_PR[i]  = new TH2D("h_Ele_tight_pt_eta_PR",  "", nptbin, ptbins, netabin, etabins);
+    
+    h_Muon_loose_pt_PR[i] = new TH1D("h_Muon_loose_pt_PR", "", nptbin, ptbins);
+    h_Muon_tight_pt_PR[i] = new TH1D("h_Muon_tight_pt_PR", "", nptbin, ptbins);
+    h_Ele_loose_pt_PR[i]  = new TH1D("h_Ele_loose_pt_PR",  "", nptbin, ptbins);
+    h_Ele_tight_pt_PR[i]  = new TH1D("h_Ele_tight_pt_PR",  "", nptbin, ptbins);
+    
+    h_Muon_loose_eta_PR[i] = new TH1D("h_Muon_loose_eta_PR", "", netabin, etabins);
+    h_Muon_tight_eta_PR[i] = new TH1D("h_Muon_tight_eta_PR", "", netabin, etabins);
+    h_Ele_loose_eta_PR[i]  = new TH1D("h_Ele_loose_eta_PR",  "", netabin, etabins);
+    h_Ele_tight_eta_PR[i]  = new TH1D("h_Ele_tight_eta_PR",  "", netabin, etabins);
+  }
+  
+}
+
+//------------------------------------------------------------------------------
+// SlaveBegin
+//------------------------------------------------------------------------------
+void nanoFakes_conept::SlaveBegin(TTree*)
+{
+  // The SlaveBegin() function is called after the Begin() function.
+  // When running with PROOF SlaveBegin() is called on each slave server.
+  // The tree argument is deprecated (on PROOF 0 is passed).
+}
+
+
+Bool_t nanoFakes_conept::Process(Long64_t entry)
+{
+  // The Process() function is called for each entry in the tree (or possibly
+  // keyed object in the case of PROOF) to be processed. The entry argument
+  // specifies which entry in the currently loaded tree is to be processed.
+  // When processing keyed objects with PROOF, the object is already loaded
+  // and is available via the fObject pointer.
+  //
+  // This function should contain the \"body\" of the analysis. It can contain
+  // simple or elaborate selection criteria, run algorithms on the data
+  // of the event and typically fill histograms.
+  //
+  // The processing can be stopped by calling Abort().
+  //
+  // Use fStatus to set the return value of TTree::Process().
+  //
+  // The return value is currently not used.
+
+  fReader.SetEntry(entry);  
+
+  if (entry > maxentries && maxentries > -1) return 0;
+  if (entry%20000 == 0) printf(" Entry number %lld \n", entry); 	 
+
+  nentries++;
+ 
+  channel = (abs(Lepton_pdgId[0]) == 11) ? e : m;
+
+  leptonPtMin  = (channel == e) ?  13 :  10;  // [GeV]
+  leptonEtaMax = (channel == e) ? 2.5 : 2.4;  // [GeV]
+
+
+  if (Lepton_pt[0] < leptonPtMin) return 0;
+  if (fabs(Lepton_eta[0]) > leptonEtaMax) return 0;
+
+  event_weight = 1.0;
+
+
+  // Make Z candidate
+  //------------------------------------------------------------------------  
+  Zlepton1type   = Loose;
+  Zlepton2type   = Loose;
+  Zlepton1idisoW = 1.0;
+  Zlepton2idisoW = 1.0;
+
+  m2l = -999.0;
+
+  if (*nLepton >= 2) {
+    for (unsigned int iLep1=0; iLep1<*nLepton; iLep1++) {
+      
+      if (Lepton_pt[iLep1] < 25.) continue;
+
+      if ((abs(Lepton_pdgId[iLep1]) == 11 && eleTightWP[iLep1] > 0.5) ||
+	  (abs(Lepton_pdgId[iLep1]) == 13 && muonTightWP[iLep1] > 0.5)) {
+
+	Zlepton1type   = Tight;
+	Zdecayflavour  = abs(Lepton_pdgId[iLep1]);
+	Zlepton1idisoW = 1.0;  // Temporary value until put in the trees
+      }
+
+      for (unsigned int iLep2=iLep1+1; iLep2<*nLepton; iLep2++) {
+	
+	if (Lepton_pt[iLep2] < 10.) continue;
+
+	if (Lepton_pdgId[iLep1] + Lepton_pdgId[iLep2] != 0) continue;
+
+	float mass1 = (abs(Lepton_pdgId[iLep1]) == 11) ? 0.000511 : 0.106;
+	float mass2 = (abs(Lepton_pdgId[iLep2]) == 11) ? 0.000511 : 0.106;
+
+	tlv1.SetPtEtaPhiM(Lepton_pt[iLep1], Lepton_eta[iLep1], Lepton_phi[iLep1], mass1);
+	tlv2.SetPtEtaPhiM(Lepton_pt[iLep2], Lepton_eta[iLep2], Lepton_phi[iLep2], mass2);
+
+	float inv_mass = (tlv1 + tlv2).M();
+
+	if (m2l < 0 || fabs(inv_mass - 91.188) < fabs(m2l - 91.188)) {
+	  
+	  m2l = inv_mass;
+
+	  leptonIndex = iLep2;
+	  
+	  // Is the second lepton tight?
+	  if ((abs(Lepton_pdgId[iLep2]) == 11 && eleTightWP[iLep2] > 0.5) ||
+	      (abs(Lepton_pdgId[iLep2]) == 13 && muonTightWP[iLep2] > 0.5)) {
+	    
+	    Zlepton2type   = Tight;
+	    Zlepton2idisoW = 1.0;  // Temporary value until put in the trees
+	  }
+	}
+      }
+    }
+  }
+
+  l2tight_weight = Zlepton1idisoW * Zlepton2idisoW;
+
+
+  // Get the event weight
+  //----------------------------------------------------------------------------
+  bool passTrigger = false;
+
+  if (ismc) {
+    
+    event_weight = (*baseW/1e3) * (*puWeight) * (*Generator_weight);
+
+    if (channel == m) {
+      
+      (Lepton_pt[0] <= 20.) ? event_weight *= muonLowPtPrescale : event_weight *= muonHighPtPrescale;  // Luminosity in fb-1 from brilcalc
+      
+      if (Lepton_pt[0] <= 20. && *HLT_Mu8 > 0.5) {
+	
+	passTrigger = true;
+	
+      } else if (Lepton_pt[0] > 20. && *HLT_Mu17 > 0.5) {
+	
+	passTrigger = true;
+      }
+    }
+
+    if (channel == e) {
+      
+      (Lepton_pt[0] <= 25.) ? event_weight *= eleLowPtPrescale : event_weight *= eleHighPtPrescale;  // Luminosity in fb-1 from brilcalc
+      
+      if (Lepton_pt[0] <= 25. && *HLT_Ele8_CaloIdM_TrackIdM_PFJet30 > 0.5) {
+	
+	passTrigger = true;
+	
+      } else if (Lepton_pt[0] > 25. && *HLT_Ele23_CaloIdM_TrackIdM_PFJet30 > 0.5) {
+	
+	passTrigger = true;
+      }
+    }
+
+  } else {
+
+    if ((filename.Contains("DoubleMuon") or filename.Contains("SingleMuon")) && channel == m) {
+      
+      if (Lepton_pt[0] <= 20. && *HLT_Mu8 > 0.5) {
+      
+	passTrigger = true;
+	
+      } else if (Lepton_pt[0] > 20. && *HLT_Mu17 > 0.5) {
+
+	passTrigger = true;
+      }
+    }
+
+    if ((filename.Contains("SingleEle") or filename.Contains("DoubleEG") or filename.Contains("EGamma")) && channel == e) {
+      
+      if (Lepton_pt[0] <= 25. && *HLT_Ele8_CaloIdM_TrackIdM_PFJet30 > 0.5) {
+	
+	passTrigger = true;
+	
+      } else if (Lepton_pt[0] > 25. && *HLT_Ele23_CaloIdM_TrackIdM_PFJet30 > 0.5) {
+	
+	passTrigger = true;
+      }
+    }
+  }
+
+        counter2 ++;
+
+  // Away jet determination
+  //----------------------------------------------------------------------------
+  if (*nCleanJet > 0) {
+
+    TLorentzVector tlvLepton;
+  
+    tlvLepton.SetPtEtaPhiM(Lepton_pt[0], Lepton_eta[0], Lepton_phi[0], 0);
+
+	  counter1 ++;
+
+    for (int i=0; i<njetet; i++) {
+    
+      jetIndex = -1;
+
+      inputJetEt = (channel == e) ? elejetet[i] : muonjetet[i];
+    
+      //loop over jets to find away jet (deltaR(lep,jet) > 1, jet pT > 10, jet |eta| < 2.5)
+      for (unsigned int j=0; j<*nCleanJet; j++) {
+      
+	if (CleanJet_pt[j] < 10.) continue;
+	if (abs(CleanJet_eta[j]) > 2.5) continue;
+	if (CleanJet_pt[j] < inputJetEt) continue;
+
+	TLorentzVector tlvJet;
+	
+	tlvJet.SetPtEtaPhiM(CleanJet_pt[j], CleanJet_eta[j], CleanJet_phi[j], 0);
+
+	deltaR = tlvJet.DeltaR(tlvLepton);
+	
+	if (deltaR > 1) {
+
+	  jetIndex = j;
+	  
+	  break;
+	}	
+      }
+
+      bool passJets = (jetIndex != -1);
+      //bool passJets = true;
+      
+
+      // QCD region
+      //------------------------------------------------------------------------
+      bool passCuts = passTrigger;
+
+      passCuts &= (*nLepton == 1);
+      passCuts &= (*mtw1 < 20.);
+      passCuts &= (*PuppiMET_pt < 20.);
+
+      FillLevelHistograms(FR_00_QCD, i, passJets && passCuts);
+      //FillLevelHistograms(FR_00_QCD, i, true);
+
+      // Z region
+      //------------------------------------------------------------------------
+      passCuts = passTrigger;
+
+      passCuts &= (*nLepton > 1);
+      passCuts &= (*PuppiMET_pt < 20.);
+      passCuts &= (m2l > 20.);
+
+
+      FillLevelHistograms(FR_01_Zpeak, i, passJets && passCuts);
+    }
+  }
+
+
+  // Fill prompt rate histograms
+  //----------------------------------------------------------------------------
+  if ((76. < m2l && 106. > m2l) && filename.Contains("DY") && Zlepton1type == Tight) {
+
+    float Zlep2pt  = Lepton_pt[leptonIndex];
+    float Zlep2eta = fabs(Lepton_eta[leptonIndex]);
+    
+    if (fabs(Zdecayflavour) == 11) {
+    
+      h_Ele_loose_pt_eta_PR[PR_00]->Fill(Zlep2pt, Zlep2eta, event_weight);
+      h_Ele_loose_pt_PR[PR_00]    ->Fill(Zlep2pt,  event_weight);
+      h_Ele_loose_eta_PR[PR_00]   ->Fill(Zlep2eta, event_weight);
+      
+      if (Zlepton2type == Tight) {
+      
+	h_Ele_tight_pt_eta_PR[PR_00]->Fill(Zlep2pt, Zlep2eta, event_weight);
+	h_Ele_tight_pt_PR[PR_00]    ->Fill(Zlep2pt,  event_weight);
+	h_Ele_tight_eta_PR[PR_00]   ->Fill(Zlep2eta, event_weight);
+      }
+      
+    } else if (fabs(Zdecayflavour) == 13) {
+      
+      h_Muon_loose_pt_eta_PR[PR_00]->Fill(Zlep2pt, Zlep2eta, event_weight);
+      h_Muon_loose_pt_PR[PR_00]    ->Fill(Zlep2pt,  event_weight);
+      h_Muon_loose_eta_PR[PR_00]   ->Fill(Zlep2eta, event_weight);
+      
+      if (Zlepton2type == Tight) {
+	
+	h_Muon_tight_pt_eta_PR[PR_00]->Fill(Zlep2pt, Zlep2eta, event_weight);
+	h_Muon_tight_pt_PR[PR_00]    ->Fill(Zlep2pt,  event_weight);
+	h_Muon_tight_eta_PR[PR_00]   ->Fill(Zlep2eta, event_weight);
+      }
+    }
+  }
+
+  return kTRUE;
+}
+
+
+//------------------------------------------------------------------------------
+// SlaveTerminate
+//------------------------------------------------------------------------------
+void nanoFakes_conept::SlaveTerminate()
+{
+  // The SlaveTerminate() function is called after all entries or objects
+  // have been processed. When running with PROOF SlaveTerminate() is called
+  // on each slave server.
+}
+
+
+//------------------------------------------------------------------------------
+// Terminate
+//------------------------------------------------------------------------------
+void nanoFakes_conept::Terminate()
+{
+  // The Terminate() function is the last function to be called during
+  // a query. It always runs on the client, it can be used to present
+  // the results graphically or save the results to file.
+
+  printf("\n Writing histograms. This can take a while...\n\n");
+
+
+  printf("Counter 1: %d \n", counter1);
+  printf("Counter 2: %d \n", counter2);
+
+  root_output->Write("", TObject::kOverwrite);
+  root_output->Close();
+}
+
+
+//------------------------------------------------------------------------------
+// FillLevelHistograms
+//------------------------------------------------------------------------------
+void nanoFakes_conept::FillLevelHistograms(int icut, int i, bool pass)
+{
+  if (!pass) return;
+
+  FillAnalysisHistograms(icut, i);
+}
+
+
+//------------------------------------------------------------------------------   
+// FillanalysisHistograms
+//------------------------------------------------------------------------------                 
+void nanoFakes_conept::FillAnalysisHistograms(int icut, int i)
+{
+  float lep1eta = fabs(Lepton_eta[0]);
+
+  for (int btag = 0; btag < nbtag ; btag ++) {
+
+    btagDirectory = btags[btag]; 
+    if(btagDirectory == "") {
+      btagDown = -10.0;
+      btagUp = 10.0;
+    } else if(btagDirectory == "bveto") {
+      btagDown = -10.0;
+      btagUp = 0.1522;
+    } else if(btagDirectory == "loose") {
+      btagDown = 0.1522;
+      btagUp = 0.4941;
+    } else if(btagDirectory == "mediumtight") {
+      btagDown = 0.4941;
+      btagUp = 10.0;
+    }
+
+
+    double cone_pt = -999.;
+    double dR_lj = 999.;
+    double thejetpt = 0.;
+    // loop over jets to find closest one for cone pt determination
+    for (unsigned int j=0; j<*nJet; j++) {
+      
+      //if (CleanJet_pt[j] < 10.) continue;
+      //if (abs(CleanJet_eta[j]) > 2.5) continue;
+      
+      TLorentzVector tlvJet;
+      
+      tlvJet.SetPtEtaPhiM(Jet_pt[j], Jet_eta[j], Jet_phi[j], 0);
+      
+      TLorentzVector tlvLepton;
+  
+      tlvLepton.SetPtEtaPhiM(Lepton_pt[0], Lepton_eta[0], Lepton_phi[0], 0);
+
+      deltaR = tlvJet.DeltaR(tlvLepton);
+      
+      if (deltaR < dR_lj) {
+	
+	dR_lj = deltaR;
+	//cout << "DEBUG: dR_lj = " << dR_lj << " and jet index is " << j << endl;
+	thejetpt = Jet_pt[j];
+	//inputJetEt = (channel == e) ? elejetet[i] : muonjetet[i];
+	double iso = (channel == e) ? Electron_miniPFRelIso_all[0] : Muon_miniPFRelIso_all[0];
+	if (deltaR > 0.4)
+	  cone_pt = Lepton_pt[0]/(Lepton_pt[0] + iso);
+	else
+	  cone_pt = 0.9*Jet_pt[j];
+      }	
+    }
+
+    //std::cout << "And the cone pt is: " << cone_pt << " (for jet pt = " << thejetpt << " and dR_lj = " << dR_lj << ")" << std::endl;
+
+    if (channel == m && Jet_btagDeepB[Muon_jetIdx[Lepton_muonIdx[0]]] > btagDown && Jet_btagDeepB[Muon_jetIdx[Lepton_muonIdx[0]]] < btagUp) {
+      
+      // Loose muons
+      //--------------------------------------------------------------------------
+      h_Muon_loose_pt_eta_bin[icut][i][btag]->Fill(cone_pt, lep1eta, event_weight);
+      h_Muon_loose_pt_bin    [icut][i][btag]->Fill(cone_pt,  event_weight);
+      h_Muon_loose_eta_bin   [icut][i][btag]->Fill(lep1eta, event_weight);
+      
+      //h_Muon_loose_dRlj_bin[icut][i][btag]->Fill(dR_lj, event_weight);
+      h_Muon_Jet_loose_pt_bin[icut][i][btag]->Fill(Jet_pt[0], event_weight);
+      // Tight muons
+      //--------------------------------------------------------------------------
+      if (muonTightWP[0] > 0.5) {
+
+	h_Muon_tight_pt_eta_bin[icut][i][btag]->Fill(cone_pt, lep1eta, event_weight);
+	h_Muon_tight_pt_bin    [icut][i][btag]->Fill(cone_pt,  event_weight);
+	h_Muon_tight_eta_bin   [icut][i][btag]->Fill(lep1eta, event_weight);
+	//h_Muon_tight_dRlj_bin[icut][i][btag]->Fill(dR_lj, event_weight);
+	h_Muon_Jet_tight_pt_bin[icut][i][btag]->Fill(Jet_pt[0], event_weight);
+	
+      }
+      
+    } else if (channel == e && Jet_btagDeepB[Electron_jetIdx[Lepton_electronIdx[0]]] > btagDown && Jet_btagDeepB[Electron_jetIdx[Lepton_electronIdx[0]]] < btagUp) {
+      
+      
+      // Loose electrons
+      //--------------------------------------------------------------------------
+      h_Ele_loose_pt_eta_bin[icut][i][btag]->Fill(cone_pt, lep1eta, event_weight);
+      h_Ele_loose_pt_bin    [icut][i][btag]->Fill(cone_pt,  event_weight);
+      h_Ele_loose_eta_bin   [icut][i][btag]->Fill(lep1eta, event_weight);
+      
+      //h_Ele_loose_dRlj_bin[icut][i][btag]->Fill(dR_lj, event_weight);
+      h_Ele_Jet_loose_pt_bin[icut][i][btag]->Fill(Jet_pt[0], event_weight);
+      
+      // Tight electrons
+      //--------------------------------------------------------------------------
+      if (eleTightWP[0] > 0.5) {
+	
+	h_Ele_tight_pt_eta_bin[icut][i][btag]->Fill(cone_pt, lep1eta, event_weight);
+	h_Ele_tight_pt_bin    [icut][i][btag]->Fill(cone_pt,  event_weight);
+	h_Ele_tight_eta_bin   [icut][i][btag]->Fill(lep1eta, event_weight);
+	//h_Ele_tight_dRlj_bin[icut][i][btag]->Fill(dR_lj, event_weight);
+	h_Ele_Jet_tight_pt_bin[icut][i][btag]->Fill(Jet_pt[0], event_weight);
+	
+      }
+      
+    }
+    
+  }
+}

--- a/nanoFakes_conept.h
+++ b/nanoFakes_conept.h
@@ -1,0 +1,300 @@
+//////////////////////////////////////////////////////////
+// This class has been automatically generated on
+// Mon Jul 23 15:59:15 2018 by ROOT version 6.10/09
+// from TTree Events/Events
+// found on file: /eos/cms/store/group/phys_higgs/cmshww/amassiro/HWWNano/Run2017_nAOD_v1_Study2017/DATAl1loose2017/nanoLatino_DoubleMuon_Run2017C-31Mar2018-v1__part0.root
+//////////////////////////////////////////////////////////
+
+#ifndef nanoFakes_conept_h
+#define nanoFakes_conept_h
+
+#include <TROOT.h>
+#include <TChain.h>
+#include <TFile.h>
+#include <TSelector.h>
+#include <TTreeReader.h>
+#include <TTreeReaderValue.h>
+#include <TTreeReaderArray.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TLorentzVector.h>
+
+enum {
+  e,
+  m,
+  l, 
+  nchannel  // This line should be always last
+};
+
+const TString schannel[nchannel] = {
+  "e",
+  "m",
+  "l",
+};
+
+const TString lchannel[nchannel] = {
+  "e",
+  "#mu",
+  "l",
+};
+
+const int njetet = 7; 
+const Double_t muonjetet[njetet] = {10, 15, 20, 25, 30, 35, 45}; 
+const Double_t elejetet [njetet] = {10, 15, 20, 25, 30, 35, 45}; 
+
+//reco pt
+const int nptbin = 8;
+const Double_t ptbins[nptbin+1] = {10, 15, 20, 25, 30, 35, 40, 45, 50};
+//cone pt
+//const int nptbin = 20;
+//const Double_t ptbins[nptbin+1] = {0, 2.5, 5, 7.5, 10, 12.5, 15, 17.5, 20, 22.5, 25, 27.5, 30, 32.5, 35, 37.5, 40, 42.5, 45, 47.5, 50};
+// cone pt, wider pt range for plotting
+//const int nptbin = 20;
+//const Double_t ptbins[nptbin+1] = {0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100};
+
+const int netabin = 5;
+const Double_t etabins[netabin+1] = {0, 0.5, 1.0, 1.5, 2.0, 2.5};
+
+//Btag division                                                                        
+const int nbtag = 4;
+const TString btags[nbtag] = {"", "bveto", "loose", "mediumtight"};
+float btagDown = 0.0;
+float btagUp = 1.0;
+TString btagDirectory = "";
+
+// Z candidate
+int   Zlepton1type;
+int   Zlepton2type;
+float Zlepton1idisoW;
+float Zlepton2idisoW;
+int   Zdecayflavour;
+float m2l;
+
+enum {Loose, Tight};
+
+enum {
+  FR_00_QCD,
+  FR_01_Zpeak,
+  ncutFR
+};
+
+const TString scutFR[ncutFR] = {
+  "FR/00_QCD",
+  "FR/01_Zpeak",
+};
+
+enum {
+  PR_00,
+  ncutPR
+};
+
+const TString scutPR[ncutPR] = {
+  "PR/00",
+};
+
+//------------------------------------------------------------------------------
+// nanoFakes_conept constructor
+//------------------------------------------------------------------------------
+class nanoFakes_conept : public TSelector
+{
+ public :
+
+  TTreeReader fReader;     //!the tree reader
+  TTree*      fChain = 0;  //!pointer to the analyzed TTree or TChain
+
+  void FillAnalysisHistograms(int  icut,
+			      int  i);
+
+   void FillLevelHistograms  (int  icut,
+			      int  i,
+			      bool pass);
+
+
+   // Fake rate histograms
+   //---------------------------------------------------------------------------
+   TH2D* h_Muon_loose_pt_eta_bin[ncutFR][njetet][nbtag];
+   TH2D* h_Muon_tight_pt_eta_bin[ncutFR][njetet][nbtag];
+   TH2D* h_Ele_loose_pt_eta_bin [ncutFR][njetet][nbtag];
+   TH2D* h_Ele_tight_pt_eta_bin [ncutFR][njetet][nbtag];
+
+   TH1D* h_Muon_loose_pt_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Muon_tight_pt_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Ele_loose_pt_bin [ncutFR][njetet][nbtag];
+   TH1D* h_Ele_tight_pt_bin [ncutFR][njetet][nbtag];
+
+   TH1D* h_Muon_loose_conv_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Muon_tight_conv_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Ele_loose_conv_bin [ncutFR][njetet][nbtag];
+   TH1D* h_Ele_tight_conv_bin [ncutFR][njetet][nbtag];
+
+   TH1D* h_Muon_loose_eta_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Muon_tight_eta_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Ele_loose_eta_bin [ncutFR][njetet][nbtag];
+   TH1D* h_Ele_tight_eta_bin [ncutFR][njetet][nbtag];
+
+
+   TH1D* h_Muon_Jet_loose_pt_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Muon_Jet_tight_pt_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Ele_Jet_loose_pt_bin[ncutFR][njetet][nbtag];
+   TH1D* h_Ele_Jet_tight_pt_bin[ncutFR][njetet][nbtag];
+
+   //TH1D* h_Muon_loose_dRlj_bin[ncutFR][njetet][nbtag];
+   //TH1D* h_Ele_loose_dRlj_bin[ncutFR][njetet][nbtag];
+   //TH1D* h_Muon_tight_dRlj_bin[ncutFR][njetet][nbtag];
+   //TH1D* h_Ele_tight_dRlj_bin[ncutFR][njetet][nbtag];
+
+   // Prompt rate histograms
+   //---------------------------------------------------------------------------
+   TH2D* h_Muon_loose_pt_eta_PR[ncutPR];
+   TH2D* h_Muon_tight_pt_eta_PR[ncutPR];
+   TH2D* h_Ele_loose_pt_eta_PR[ncutPR];
+   TH2D* h_Ele_tight_pt_eta_PR[ncutPR];
+
+   TH1D* h_Muon_loose_pt_PR[ncutPR];
+   TH1D* h_Muon_tight_pt_PR[ncutPR];
+   TH1D* h_Ele_loose_pt_PR[ncutPR];
+   TH1D* h_Ele_tight_pt_PR[ncutPR];
+
+   TH1D* h_Muon_loose_eta_PR[ncutPR];
+   TH1D* h_Muon_tight_eta_PR[ncutPR];
+   TH1D* h_Ele_loose_eta_PR[ncutPR];
+   TH1D* h_Ele_tight_eta_PR[ncutPR];
+
+
+   // Readers to access the data (delete the ones you do not need)
+   //---------------------------------------------------------------------------
+   TTreeReaderValue<Float_t> baseW;
+   TTreeReaderValue<Float_t> Xsec;
+   TTreeReaderValue<Float_t> puWeight;
+   TTreeReaderValue<Float_t> Generator_weight;
+
+
+   // Common variables for 2016, 2017 and 2018
+   //---------------------------------------------------------------------------
+   TTreeReaderValue<UInt_t> nLepton = {fReader, "nLepton"};
+   TTreeReaderArray<Int_t> Lepton_pdgId = {fReader, "Lepton_pdgId"};
+   TTreeReaderArray<Float_t> Lepton_pt = {fReader, "Lepton_pt"};
+   //TTreeReaderArray<Float_t> Electron_lostHits = {fReader, "Electron_lostHits"};
+   TTreeReaderArray<Float_t> Lepton_eta = {fReader, "Lepton_eta"};
+   TTreeReaderArray<Float_t> Lepton_phi = {fReader, "Lepton_phi"};
+
+   TTreeReaderArray<Float_t> Jet_btagDeepB = {fReader, "Jet_btagDeepB"};
+   TTreeReaderArray<Int_t> Lepton_muonIdx = {fReader, "Lepton_muonIdx"};
+   TTreeReaderArray<Int_t> Muon_jetIdx = {fReader, "Muon_jetIdx"};
+   TTreeReaderArray<Int_t> Lepton_electronIdx = {fReader, "Lepton_electronIdx"};
+   TTreeReaderArray<Int_t> Electron_jetIdx = {fReader, "Electron_jetIdx"};
+
+   TTreeReaderArray<Float_t> Muon_mvaTTH = {fReader, "Muon_mvaTTH"};
+   TTreeReaderArray<Float_t> Electron_mvaTTH = {fReader, "Electron_mvaTTH"};
+
+   TTreeReaderArray<Float_t> Electron_miniPFRelIso_all = {fReader, "Electron_miniPFRelIso_all"};
+   TTreeReaderArray<Float_t> Muon_miniPFRelIso_all = {fReader, "Muon_miniPFRelIso_all"};
+
+   TTreeReaderValue<UInt_t> nCleanJet = {fReader, "nCleanJet"};
+   TTreeReaderArray<Float_t> CleanJet_pt = {fReader, "CleanJet_pt"};
+   TTreeReaderArray<Float_t> CleanJet_eta = {fReader, "CleanJet_eta"};
+   TTreeReaderArray<Float_t> CleanJet_phi = {fReader, "CleanJet_phi"};
+
+   TTreeReaderValue<UInt_t> nJet = {fReader, "nJet"};
+   TTreeReaderArray<Float_t> Jet_pt = {fReader, "Jet_pt"};
+   TTreeReaderArray<Float_t> Jet_eta = {fReader, "Jet_eta"};
+   TTreeReaderArray<Float_t> Jet_phi = {fReader, "Jet_phi"};
+   
+   TTreeReaderValue<Float_t> mtw1 = {fReader, "mtw1"};
+   TTreeReaderValue<Float_t> PuppiMET_pt = {fReader, "PuppiMET_pt"};
+   TTreeReaderValue<Float_t> dphilep1jet1 = {fReader, "dphilep1jet1"};
+   TTreeReaderValue<Float_t> Electron_pfRelIso03_all = {fReader, "Electron_pfRelIso03_all"};
+
+   TTreeReaderValue<Bool_t> HLT_Mu8 = {fReader, "HLT_Mu8"};
+   TTreeReaderValue<Bool_t> HLT_Mu17 = {fReader, "HLT_Mu17"};
+   TTreeReaderValue<Bool_t> HLT_Ele8_CaloIdM_TrackIdM_PFJet30 = {fReader, "HLT_Ele8_CaloIdM_TrackIdM_PFJet30"};
+   TTreeReaderValue<Bool_t> HLT_Ele23_CaloIdM_TrackIdM_PFJet30 = {fReader, "HLT_Ele23_CaloIdM_TrackIdM_PFJet30"};
+
+
+   //Different electron and muon working points
+   //---------------------------------------------------------------------------
+
+   // 2016
+   ////TTreeReaderArray<Int_t> muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight80x"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cut_WP_Tight80X"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cut_WP_Tight80X_SS"};
+   ////TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016"};
+   ////TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mva_90p_Iso2016_SS"};
+
+   // 2017
+   TTreeReaderArray<Int_t> muonTightWP = {fReader, ""}; // just a placeholder -- see nanoFakes_conept.C where WP is actually set/defined
+   TTreeReaderArray<Int_t> eleTightWP = {fReader, ""}; // just a placeholder -- see nanoFakes_conept.C where WP is actually set/defined
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight_SS"};
+
+   // 2018
+   //TTreeReaderArray<Int_t> muonTightWP = {fReader, "Lepton_isTightMuon_cut_Tight_HWWW"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V1Iso_WP90_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_mvaFall17V2Iso_WP90_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V1Iso_Tight_SS"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight"};
+   //TTreeReaderArray<Int_t> eleTightWP = {fReader, "Lepton_isTightElectron_cutFall17V2Iso_Tight_SS"};
+
+   nanoFakes_conept(TTree * /*tree*/ =0) { }
+   virtual ~nanoFakes_conept() { }
+   virtual Int_t   Version() const { return 2; }
+   virtual void    Begin(TTree *tree);
+   virtual void    SlaveBegin(TTree *tree);
+   virtual void    Init(TTree *tree);
+   virtual Bool_t  Notify();
+   virtual Bool_t  Process(Long64_t entry);
+   virtual Int_t   GetEntry(Long64_t entry, Int_t getall = 0) { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
+   virtual void    SetOption(const char *option) { fOption = option; }
+   virtual void    SetObject(TObject *obj) { fObject = obj; }
+   virtual void    SetInputList(TList *input) { fInput = input; }
+   virtual TList  *GetOutputList() const { return fOutput; }
+   virtual void    SlaveTerminate();
+   virtual void    Terminate();
+
+   ClassDef(nanoFakes_conept,0);
+};
+
+#endif
+
+#ifdef nanoFakes_conept_cxx
+
+
+//------------------------------------------------------------------------------
+// Init
+//------------------------------------------------------------------------------
+void nanoFakes_conept::Init(TTree *tree)
+{
+  // The Init() function is called when the selector needs to initialize
+  // a new tree or chain. Typically here the reader is initialized.
+  // It is normally not necessary to make changes to the generated
+  // code, but the routine can be extended by the user if needed.
+  // Init() will be called many times when running on PROOF
+  // (once per file to be processed).
+  
+  fReader.SetTree(tree);
+}
+
+
+//------------------------------------------------------------------------------
+// Notify
+//------------------------------------------------------------------------------
+Bool_t nanoFakes_conept::Notify()
+{
+  // The Notify() function is called when a new file is opened. This
+  // can be either for a new TTree in a TChain or when when a new TTree
+  // is started when using PROOF. It is normally not necessary to make changes
+  // to the generated code, but the routine can be extended by the
+  // user if needed. The return value is currently not used.
+
+  return kTRUE;
+}
+
+#endif // #ifdef nanoFakes_conept_cxx


### PR DESCRIPTION
This pull request is for two new files nanoFakes_conept.C and nanoFakes_conept.h, which I made for the cone pT fake-rate studies. They are similar to the analogous files nanoFakes.C and nanoFakes.h (the eta plots are exactly the same), except that instead of producing histograms of lepton[0] pT for tight and loose leptons, they produce histograms of lepton[0] cone pT (same histogram names, just plotting a different variable).
To run the code, one just needs to replace "nanoFakes.C" with "nanoFakes_conept.C" in runNanoFakes.C, and then run submitJobs.py exactly the same way as in the README. The resulting output root files, once hadded, can then be processed with getFakeRates.C in the same way as the output of nanoFakes.C.